### PR TITLE
Adds Growth plan template

### DIFF
--- a/.github/ISSUE_TEMPLATE/growth-plan-checklist-template.md
+++ b/.github/ISSUE_TEMPLATE/growth-plan-checklist-template.md
@@ -1,0 +1,16 @@
+---
+name: Growth Plan Checklist
+about: For capturing action items related to growth plan for progression to Impact stage
+title: "[GROWTH PLAN] ${Project Name}"
+labels: 'Growth Plan'
+assignees: ''
+---
+
+**Growth plan:** ${Link to growth plan}
+
+- [ ] Fill in [growth plan template](https://github.com/openjs-foundation/project-status/blob/master/GROWTH_PLAN_TEMPLATE.md)
+- [ ] Submit growth plan to CPC for approval
+- [ ] Obtain growth plan approval from CPC
+- [ ] Complete growth plan
+- [ ] Submit completed growth plan to CPC for graduation approval
+- [ ] Impact stage graduation

--- a/GROWTH_PLAN_TEMPLATE.md
+++ b/GROWTH_PLAN_TEMPLATE.md
@@ -1,0 +1,27 @@
+# ${PROJECT} Growth Plan
+
+_Note: the purpose of the growth plan is to provide a roadmap for a project to move from Growth stage to Impact stage._
+
+## Growth stage requirements
+
+_Note: in theory, Growth stage requirements should already be met by all Growth stage projects.
+As requirements might have changed after a project was accepted at the Growth stage, this isn't necessarily always the case.
+So making sure that all Growth requirements are met is a good first step in any Growth plan._
+
+| Requirement | Current status | Desired status | Plan | Timeline | Completed |
+| --- | ---| --- | --- | --- | --- | 
+| Successfully used in production by at least two independent end users. | {CURRENT_STATUS} | 2 | {PLAN} | {DATE} | <!--✅--> |
+| Substancial ongoing flow of commits and merged contributions. | {CURRENT_STATUS} | {DESIRED_STATUS} | {PLAN} | {DATE} | <!--✅--> |
+| Sufficient level of community participation to meet goals outlined in growth plan. | {CURRENT_STATUS} | {DESIRED_STATUS} | {PLAN} | {DATE} | <!--✅--> |
+| Accepts security reports and publicly disclose them after the fix has been made available. | {CURRENT_STATUS} | {DESIRED_STATUS} | {PLAN} | {DATE} | <!--✅--> |
+
+## Impact stage requirements
+
+| Requirement | Current status | Desired status | Plan | Timeline | Completed |
+| --- | ---| --- | --- | --- | --- | 
+| Governing body of >= 5 members of which no more than 1/3 is affiliated with the same employer. | {CURRENT_STATUS} | {DESIRED_STATUS} | {PLAN} | {DATE} | <!--✅--> |
+| Publicly documented governance, decision-making, contribution, and release processes. | {CURRENT_STATUS} | {DESIRED_STATUS} | {PLAN} | {DATE} | <!--✅--> |
+| Healthy number of committers from at least two organizations. | {CURRENT_STATUS} | {DESIRED_STATUS} | {PLAN} | {DATE} | <!--✅--> |
+| Adopted the Foundation Code of Conduct. | {CURRENT_STATUS} | {DESIRED_STATUS} | {PLAN} | {DATE} | <!--✅--> |
+| Public list of project adopters. | {CURRENT_STATUS} | {DESIRED_STATUS} | {PLAN} | {DATE} | <!--✅--> |
+| {OTHER_METRICS_DEFINED_WITH_CPC} | {CURRENT_STATUS} | {DESIRED_STATUS} | {PLAN} | {DATE} | <!--✅--> |

--- a/GROWTH_PLAN_TEMPLATE.md
+++ b/GROWTH_PLAN_TEMPLATE.md
@@ -10,7 +10,7 @@ So making sure that all Growth requirements are met is a good first step in any 
 
 | Requirement | Current status | Desired status | Plan | Timeline | Completed |
 | --- | ---| --- | --- | --- | --- | 
-| Successfully used in production by at least two independent end users. | {CURRENT_STATUS} | 2 | {PLAN} | {DATE} | <!--✅--> |
+| Project shows substantial adoption in production environments or usage within the ecosystem | {CURRENT_STATUS} | 2 | {PLAN} | {DATE} | <!--✅--> |
 | Substancial ongoing flow of commits and merged contributions. | {CURRENT_STATUS} | {DESIRED_STATUS} | {PLAN} | {DATE} | <!--✅--> |
 | Sufficient level of community participation to meet goals outlined in growth plan. | {CURRENT_STATUS} | {DESIRED_STATUS} | {PLAN} | {DATE} | <!--✅--> |
 | Accepts security reports and publicly disclose them after the fix has been made available. | {CURRENT_STATUS} | {DESIRED_STATUS} | {PLAN} | {DATE} | <!--✅--> |
@@ -21,7 +21,7 @@ So making sure that all Growth requirements are met is a good first step in any 
 | --- | ---| --- | --- | --- | --- | 
 | Governing body of >= 5 members of which no more than 1/3 is affiliated with the same employer. | {CURRENT_STATUS} | {DESIRED_STATUS} | {PLAN} | {DATE} | <!--✅--> |
 | Publicly documented governance, decision-making, contribution, and release processes. | {CURRENT_STATUS} | {DESIRED_STATUS} | {PLAN} | {DATE} | <!--✅--> |
-| Healthy number of committers from at least two organizations. | {CURRENT_STATUS} | {DESIRED_STATUS} | {PLAN} | {DATE} | <!--✅--> |
+| Healthy number of regular committers from at least two organizations. | {CURRENT_STATUS} | {DESIRED_STATUS} | {PLAN} | {DATE} | <!--✅--> |
 | Adopted the Foundation Code of Conduct. | {CURRENT_STATUS} | {DESIRED_STATUS} | {PLAN} | {DATE} | <!--✅--> |
 | Public list of project adopters. | {CURRENT_STATUS} | {DESIRED_STATUS} | {PLAN} | {DATE} | <!--✅--> |
 | {OTHER_METRICS_DEFINED_WITH_CPC} | {CURRENT_STATUS} | {DESIRED_STATUS} | {PLAN} | {DATE} | <!--✅--> |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,21 @@
-# project-onboarding
-Public repo to manage the process of onboarding projects
+# project-status
+
+Public repo to manage the processes of project onboarding and growth plan approval and monitoring.
 
 ## Resources for onboarding projects
 
+* [Onboarding checklist](https://github.com/openjs-foundation/cross-project-council/blob/master/PROJECT_PROGRESSION.md#onboarding-checklist)
+
 * [OpenJS Foundation Marketing Support Opportunities](https://docs.google.com/presentation/d/1xWsohwo-SwKjR-GuThi0BVwz3ni7KLp3vIBTuAbMQRY/edit#slide=id.g5ce6a1b7ed_5_14): A presentation from the marketing team about resources available to you to market your project 
+
+# Growth plan process
+
+Project which want to move to [Impact stage](https://github.com/openjs-foundation/cross-project-council/blob/master/PROJECT_PROGRESSION.md#impact-stage) need to provide and implement a Growth Plan. There is a [growth plan template](GROWTH_PLAN_TEMPLATE.md) available as a starting point.
+
+## Process
+
+* Project fills in the growth plan template. (The growth plan can be hosted on the project's own infrastructure or in the `growth-plan` directory of this repository.)
+* The project decides itself of the goals it sets in the growth plan according to the [Impact stage acceptance criteria](https://github.com/openjs-foundation/cross-project-council/blob/master/PROJECT_PROGRESSION.md#impact-stage) and sets the roadmap for meeting them.
+* The growth plan is then submitted to the Cross Project Council (CPC) for approval by filing a _Project Growth Plan Checklist_ issue in this repository.
+* The CPC regularly checks on the progress of the growth plan according to its [review process](https://github.com/openjs-foundation/cross-project-council/blob/master/PROJECT_PROGRESSION.md#iv-annual-review-process).
+

--- a/README.md
+++ b/README.md
@@ -16,6 +16,6 @@ Project which want to move to [Impact stage](https://github.com/openjs-foundatio
 
 * Project fills in the growth plan template. (The growth plan can be hosted on the project's own infrastructure or in the `growth-plan` directory of this repository.)
 * The project decides itself of the goals it sets in the growth plan according to the [Impact stage acceptance criteria](https://github.com/openjs-foundation/cross-project-council/blob/master/PROJECT_PROGRESSION.md#impact-stage) and sets the roadmap for meeting them.
-* The growth plan is then submitted to the Cross Project Council (CPC) for approval by filing a _Project Growth Plan Checklist_ issue in this repository.
+* The growth plan is then submitted to the Cross Project Council (CPC) for approval by filing a _Growth Plan Checklist_ issue in this repository.
 * The CPC regularly checks on the progress of the growth plan according to its [review process](https://github.com/openjs-foundation/cross-project-council/blob/master/PROJECT_PROGRESSION.md#iv-annual-review-process).
 


### PR DESCRIPTION
This is a first path at creating a growth plan template for Growth stage projects wanting to join Impact stage done by @tobie in the CPC repo, but we decided to move it to this repo.

https://github.com/openjs-foundation/cross-project-council/pull/647

As stated in that PR:

From a previous CPC meeting discussion:

- [x] Move this PR to project-status
- [x] Add process in the readme which includes:
  - [x] Projects define their desired status themselves.
  - [x] Projects ask for CPC approval of the roadmap.
  
Closes https://github.com/openjs-foundation/cross-project-council/issues/692.